### PR TITLE
external/core-004-case-modifier

### DIFF
--- a/src/GrowingData.Utilities/Strings/CaseModifiers.cs
+++ b/src/GrowingData.Utilities/Strings/CaseModifiers.cs
@@ -57,22 +57,7 @@ namespace GrowingData.Utilities {
 			if (name == null) {
 				return null;
 			}
-
-
-			var renamed = new StringBuilder();
-			for (var i = 0; i < name.Length; i++) {
-				if (name[i] == ' ' || name[i] == '-' || name[i] == '_') {
-					renamed.Append("_");
-					continue;
-				}
-				if (!char.IsLetterOrDigit(name[i])) {
-					// Ignore invalid characters
-					continue;
-				}
-
-				renamed.Append(char.ToLower(name[i]));
-			}
-			return renamed.ToString();
+			return ToDnsSafeLabel(name).Replace("-", "_");
 		}
 	}
 }


### PR DESCRIPTION
…on in code paths.When using CaseModifiers.ToDatabaseSafeLabel, when we have a string like “FirstName”, it is being returned as “firstname” rather than the more pleasant “first_name”.